### PR TITLE
Hide status bar and navigation bar

### DIFF
--- a/googlemediaframework/src/main/res/layout/playback_control_layer.xml
+++ b/googlemediaframework/src/main/res/layout/playback_control_layer.xml
@@ -37,7 +37,7 @@
             android:singleLine="true"
             android:ellipsize="end"
             android:textSize="20dp"
-            android:layout_marginTop="5dp"
+            android:layout_marginTop="3dp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_weight="0"
@@ -77,7 +77,7 @@
             android:paddingTop="5dp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="4dp"
+            android:layout_marginLeft="15dp"
             android:textColor="@android:color/white"/>
         <SeekBar
             android:id="@+id/mediacontroller_progress"
@@ -87,6 +87,7 @@
         <TextView
             android:id="@+id/time_duration"
             android:paddingTop="5dp"
+            android:layout_marginRight="10dp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textColor="@android:color/white"/>


### PR DESCRIPTION
Navigation bar and status bar hide when in fullscreen mode (swiping from the edge, inward will bring them back).
