### PR TITLE
Fix for seekbar disappearing when dragging

### DIFF
--- a/googlemediaframework/src/main/java/com/google/android/libraries/mediaframework/layeredvideo/PlaybackControlLayer.java
+++ b/googlemediaframework/src/main/java/com/google/android/libraries/mediaframework/layeredvideo/PlaybackControlLayer.java
@@ -646,8 +646,8 @@ public class PlaybackControlLayer implements Layer, PlayerControlCallback {
     handler.sendEmptyMessage(SHOW_PROGRESS);
 
     Message msg = handler.obtainMessage(FADE_OUT);
+    handler.removeMessages(FADE_OUT);
     if (timeout > 0) {
-      handler.removeMessages(FADE_OUT);
       handler.sendMessageDelayed(msg, timeout);
     }
   }


### PR DESCRIPTION
When seeking begins, all previous FADE_OUT messages should be removed regardless of the timeout value.  If they are not removed, the seekbar will disappear when the user is seeking.
