### PR TITLE
Allow videos to start from a given location

### DIFF
--- a/demo/src/main/java/com/google/googlemediaframeworkdemo/demo/adplayer/ImaPlayer.java
+++ b/demo/src/main/java/com/google/googlemediaframeworkdemo/demo/adplayer/ImaPlayer.java
@@ -599,6 +599,7 @@ public class ImaPlayer {
         adVideo,
         "",
         true,
+        0,
         fullscreenCallback);
 
     adPlayer.addPlaybackListener(adPlaybackListener);

--- a/googlemediaframework/src/main/java/com/google/android/libraries/mediaframework/layeredvideo/SimpleVideoPlayer.java
+++ b/googlemediaframework/src/main/java/com/google/android/libraries/mediaframework/layeredvideo/SimpleVideoPlayer.java
@@ -73,7 +73,7 @@ public class SimpleVideoPlayer {
                            Video video,
                            String videoTitle,
                            boolean autoplay) {
-    this(activity, container, video, videoTitle, autoplay, null);
+    this(activity, container, video, videoTitle, autoplay, 0, null);
   }
 
   /**
@@ -90,6 +90,7 @@ public class SimpleVideoPlayer {
                            Video video,
                            String videoTitle,
                            boolean autoplay,
+                           int startPostitionMs,
                            PlaybackControlLayer.FullscreenCallback fullscreenCallback) {
     this.activity = activity;
 
@@ -108,6 +109,10 @@ public class SimpleVideoPlayer {
         layers);
 
     layerManager.getExoplayerWrapper().setTextListener(subtitleLayer);
+
+    if (startPostitionMs > 0) {
+      layerManager.getExoplayerWrapper().seekTo(startPostitionMs);
+    }
   }
 
   /**


### PR DESCRIPTION
Currently videos can not be started from a given location.  This is necessary if a user would like to resume a video that they had been previously watching.  This enhancement will allow users to provide a starting position for the video.
