### PR TITLE
Fix for NullPointerException in VideoSurfaceLayer

### DIFF
--- a/googlemediaframework/src/main/java/com/google/android/libraries/mediaframework/layeredvideo/VideoSurfaceLayer.java
+++ b/googlemediaframework/src/main/java/com/google/android/libraries/mediaframework/layeredvideo/VideoSurfaceLayer.java
@@ -163,6 +163,9 @@ public class VideoSurfaceLayer implements Layer {
    * When you are finished using this object, call this method.
    */
   public void release() {
-    layerManager.getExoplayerWrapper().removeListener(playbackListener);
+    ExoplayerWrapper wrapper = layerManager.getExoplayerWrapper();
+    if (wrapper != null) {
+      wrapper.removeListener(playbackListener);
+    }
   }
 }


### PR DESCRIPTION
Add null check around ExoplayerWrapper in release method. Avoid
NullPointerException. Fixes issue #55
(https://github.com/googleads/google-media-framework-android/issues/55)