### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-#Contributing to Google Media Framework - Android
+# Contributing to Google Media Framework - Android
 
 Open source projects thrive because of contributions from the developer communitity. Thank you for
 considering contributing to Google Media Framework - Android!

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-#Google Media Framework for Android
+# Google Media Framework for Android
 
 [![Build Status](https://travis-ci.org/googleads/google-media-framework-android.svg?branch=master)](https://travis-ci.org/googleads/google-media-framework-android)
 
-##Introduction
+## Introduction
 The Google Media Framework (GMF) is a lightweight media player designed to make video playback and integration with the Google Interactive Media Ads (IMA) SDK on Android easier.
 
 ![Google Media Framework Android Demo](http://googleads.github.io/google-media-framework-android/gmf_android_portrait.png)
 
 The framework is currently in beta, allowing interested developers to try it out and send feedback before we finalize the APIs and features.
 
-##Features
+## Features
 - A customizable video player UI for video playback on Android
     - Logo and branding colors
     - Action buttons within video UI for other actions (ex. share or download)
@@ -18,7 +18,7 @@ The framework is currently in beta, allowing interested developers to try it out
 - Built on top of [ExoPlayer](https://github.com/google/ExoPlayer)
     - Plays [MPEG DASH](http://en.wikipedia.org/wiki/Dynamic_Adaptive_Streaming_over_HTTP), [HLS](http://en.wikipedia.org/wiki/HTTP_Live_Streaming) and mp4, and easily extended to other video formats
 
-##Getting started
+## Getting started
 
 Clone the repository
 
@@ -28,7 +28,7 @@ git clone https://github.com/googleads/google-media-framework-android.git Google
 
 Then import the project in Android Studio (or build using Gradle via `./gradlew`).
 
-###Via jCenter
+### Via jCenter
 You can also include GMF by adding the following in your project's `build.gradle` file:
 
 ```gradle
@@ -43,23 +43,23 @@ project's [Releases][]. For more details, see the project on [Bintray][].
 _Note:_ this installs the underlying `mediaframework` library. For the demo package with IMA
 integration, please download or clone the source.
 
-##Documentation
+## Documentation
 
 Please see the [Javadoc](http://googleads.github.io/google-media-framework-android/docs/)
 
-##Wiki
+## Wiki
 For a detailed description of the project, please see the [wiki](https://github.com/googleads/google-media-framework-android/wiki).
 
-##Where do I report issues?
+## Where do I report issues?
 Please report issues on the [issues page](../../issues).
 
-##Support
+## Support
 If you have questions about the framework, you can ask them in our [google group](http://groups.google.com/d/forum/google-media-framework).
 
-##How do I contribute?
+## How do I contribute?
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
 
-##I want to use a newer version of Exoplayer
+## I want to use a newer version of Exoplayer
 Change the version of ExoPlayer included in the [googlemediaframework](https://github.com/googleads/google-media-framework-android/tree/master/googlemediaframework) package's `build.grade`:
 
 ```gradle
@@ -67,12 +67,12 @@ compile 'com.google.android.exoplayer:exoplayer:rX.X.X'
 ```
 _Note:_ you may have to modify the code if any underlying ExoPlayer APIs have changed.
 
-##Requirements
+## Requirements
 
-###Deployment
+### Deployment
   - Android 4.1+
 
-###Development
+### Development
   - Gradle (1.12 or above)
   - Android Studio (0.8 or above)
     - Build tools version 19.1.0 (installed via SDK manager)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
